### PR TITLE
Added `CalendarStoreSinglePageViewController`, fixes #13.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - Alamofire (4.7.2)
   - Result (3.0.0)
-  - SchedJoulesApiClient (0.7):
+  - SchedJoulesApiClient (0.7.1):
     - Alamofire (~> 4.5)
     - Result (~> 3.0.0)
-  - SDWebImage (4.3.3):
-    - SDWebImage/Core (= 4.3.3)
-  - SDWebImage/Core (4.3.3)
+  - SDWebImage (4.4.1):
+    - SDWebImage/Core (= 4.4.1)
+  - SDWebImage/Core (4.4.1)
 
 DEPENDENCIES:
   - Alamofire (~> 4.5)
@@ -24,8 +24,8 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
   Result: 1b3e431f37cbcd3ad89c6aa9ab0ae55515fae3b6
-  SchedJoulesApiClient: 80e41fd01a5da19d34389c1864dbdda5b3e113cc
-  SDWebImage: de4d90b5bff3571eae7bd16202b1f43135409fa5
+  SchedJoulesApiClient: 4f76adcfd0191e1ca666ced92fa82bd728f84fbc
+  SDWebImage: 47e9b5b925cbce75946c23f0c42dd19464189af4
 
 PODFILE CHECKSUM: 8cd683f264b49d10f8b888f4687cd99f8b2a6f28
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,18 @@ Mail us at support@schedjoules.com to request you personal API key if you don't 
 
 ### Example
 
+If you would like to present our fully-featured Calendar Store, use the `CalendarStoreViewController` class:
+
 ```Swift
 // Presenting the Calendar Store View Controller
 let calendarVC = CalendarStoreViewController(apiKey: "YOUR_API_KEY")
 present(calendarVC, animated: true, completion: nil)
 ```
 
-Optionally, you can also pass a `pageIdentifier` to start directly from a page rather than the home.
+Optionally, if you would only like to use the Calendar Store to present a single page, use the `CalendarStoreSinglePageViewController` class:
 
 ```Swift
-// Presenting the Calendar Store View Controller with a given page
-let calendarVC = CalendarStoreViewController(apiKey: "YOUR_API_KEY", pageIdentifer: "115673")
+let calendarVC = CalendarStoreSinglePageViewController(apiKey: "YOUR_API_KEY", pageIdentifer: "115673", title: "Featured")
 present(calendarVC, animated: true, completion: nil)
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,3 @@ Optionally, if you would only like to use the Calendar Store to present a single
 let calendarVC = CalendarStoreSinglePageViewController(apiKey: "YOUR_API_KEY", pageIdentifer: "115673", title: "Featured")
 present(calendarVC, animated: true, completion: nil)
 ```
-
-### Customization options
-
-The default initializer for the Calendar Store includes parameters for customization. 
-```Swift
-init(apiClient: SchedJoulesApi, pageIdentifier: String?, title: String?, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red)
-```
-Please refer to the [inline code documentation](https://github.com/schedjoules/ios-public-calendars-sdk/blob/master/SDK/CalendarStoreViewController.swift#L61) for further details.
-

--- a/SDK/CalendarStoreSinglePageViewController.swift
+++ b/SDK/CalendarStoreSinglePageViewController.swift
@@ -1,0 +1,86 @@
+//
+//  CalendarStoreSinglePageViewController.swift
+//  iOS-SDK
+//
+//  Created by Balazs Vincze on 2018. 06. 01..
+//  Copyright © 2018. SchedJoules. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+import SchedJoulesApiClient
+
+final class CalendarStoreSinglePageViewController: UINavigationController {
+    /// Colors used by the SDK.
+    public struct ColorPalette {
+        public static let red = UIColor(red: 241/255.0, green: 102/255.0, blue: 103/255.0, alpha: 1)
+    }
+    
+    // - MARK: Initialization
+    
+    /* This method is only called when initializing a `UIViewController` from a `Storyboard` or `XIB`.
+     The `CalendarStoreSinglePageViewController` must only be used programatically, but every subclass of `UIViewController` must implement
+     `init?(coder aDecoder: NSCoder)`. */
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("CalendarStoreSinglePageViewController must only be initialized programatically.")
+    }
+    
+    /**
+     - parameter apiClient: An instance of `SchedJoulesApi`, initialized with a valid access token.
+     - parameter pageIdentifier: The page identifier for the the home page.
+     - parameter title: The title for the `navigtaion bar` in the home page.
+     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
+     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
+     */
+    public init(apiClient: SchedJoulesApi, pageIdentifier: String, title: String, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
+        super.init(nibName: nil, bundle: nil)
+        
+        // Customize the naivgation controller
+        navigationBar.tintColor = tintColor
+        if #available(iOS 11.0, *) {
+            navigationBar.prefersLargeTitles = largeTitle
+        }
+        
+        // Create home page with a specific page identifier and push it on to the navigation stack
+        let homeVC = PageViewController(apiClient: apiClient, pageQuery:
+            SinglePageQuery(pageID: pageIdentifier, locale: readSettings().last!), searchEnabled: true)
+        homeVC.title = title
+        pushViewController(homeVC, animated: false)
+    }
+    
+    /**
+     - parameter apiKey: The API Key (access token) for the **SchedJoules API**.
+     - parameter pageIdentifier: The page identifier for the the home page.
+     - parameter title: The title for the `navigtaion bar` in the home page.
+     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
+     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
+     */
+    public convenience init(apiKey: String, pageIdentifier: String, title: String, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
+        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title, largeTitle: largeTitle, tintColor: tintColor)
+    }
+    
+    /// Read localization settings, use device defaults otherwise
+    func readSettings() -> [String] {
+        let languageSetting = UserDefaults.standard.value(forKey: "language_settings") as? Dictionary<String, String>
+        let locale = languageSetting != nil ? languageSetting!["countryCode"] : Locale.preferredLanguages[0].components(separatedBy: "-")[0]
+        let countrySetting = UserDefaults.standard.value(forKey: "country_settings") as? Dictionary<String, String>
+        let location = countrySetting != nil ? countrySetting!["countryCode"] : Locale.current.regionCode
+        return [locale!,location!]
+    }
+}

--- a/SDK/CalendarStoreSinglePageViewController.swift
+++ b/SDK/CalendarStoreSinglePageViewController.swift
@@ -48,13 +48,13 @@ final class CalendarStoreSinglePageViewController: UINavigationController {
      - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
      - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
-    public init(apiClient: SchedJoulesApi, pageIdentifier: String, title: String, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
+    public init(apiClient: Api, pageIdentifier: String, title: String) {
         super.init(nibName: nil, bundle: nil)
         
         // Customize the naivgation controller
-        navigationBar.tintColor = tintColor
+        navigationBar.tintColor = ColorPalette.red
         if #available(iOS 11.0, *) {
-            navigationBar.prefersLargeTitles = largeTitle
+            navigationBar.prefersLargeTitles = true
         }
         
         // Create home page with a specific page identifier and push it on to the navigation stack
@@ -71,8 +71,8 @@ final class CalendarStoreSinglePageViewController: UINavigationController {
      - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
      - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
-    public convenience init(apiKey: String, pageIdentifier: String, title: String, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
-        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title, largeTitle: largeTitle, tintColor: tintColor)
+    public convenience init(apiKey: String, pageIdentifier: String, title: String) {
+        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title)
     }
     
     /// Read localization settings, use device defaults otherwise

--- a/SDK/CalendarStoreSinglePageViewController.swift
+++ b/SDK/CalendarStoreSinglePageViewController.swift
@@ -45,8 +45,6 @@ final class CalendarStoreSinglePageViewController: UINavigationController {
      - parameter apiClient: An instance of `SchedJoulesApi`, initialized with a valid access token.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
-     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
-     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
     public init(apiClient: Api, pageIdentifier: String, title: String) {
         super.init(nibName: nil, bundle: nil)
@@ -68,8 +66,6 @@ final class CalendarStoreSinglePageViewController: UINavigationController {
      - parameter apiKey: The API Key (access token) for the **SchedJoules API**.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
-     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
-     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
     public convenience init(apiKey: String, pageIdentifier: String, title: String) {
         self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title)

--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -59,7 +59,7 @@ public final class CalendarStoreViewController: UITabBarController {
     }
     
     /**
-     - parameter apiKey: The API Key (access token) for the **SchedJoules API**.
+     - parameter apiClient: An instance of `SchedJoulesApi`, initialized with a valid access token.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
      - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
@@ -79,6 +79,17 @@ public final class CalendarStoreViewController: UITabBarController {
         
         // Add the view controllers to the tab bar controller
         addViewControllers()
+    }
+    
+    /**
+     - parameter apiKey: The API Key (access token) for the **SchedJoules API**.
+     - parameter pageIdentifier: The page identifier for the the home page.
+     - parameter title: The title for the `navigtaion bar` in the home page.
+     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
+     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
+     */
+    public convenience init(apiKey: String, pageIdentifier: String?, title: String?, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
+        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title, largeTitle: largeTitle, tintColor: tintColor)
     }
     
     /**
@@ -121,7 +132,7 @@ public final class CalendarStoreViewController: UITabBarController {
             homeVC.title = homePageTitle
             homeVC.tabBarItem.image = UIImage(named: "Featured", in: Bundle.resourceBundle, compatibleWith: nil)
             tabViewControllers.append(homeVC)
-            // Create home page with juts localization parameters
+            // Create home page with just localization parameters
         } else {
             let homeVC = PageViewController(apiClient: apiClient, pageQuery:
                 HomePageQuery(locale: readSettings().first!, location: readSettings().last!), searchEnabled: true)

--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -33,7 +33,7 @@ public final class CalendarStoreViewController: UITabBarController {
     }
     
     /// The ApiClient to be used by the view controllers.
-    private let apiClient: SchedJoulesApi
+    private let apiClient: Api
     
     /// The page identifier to be passed to the home page.
     private let pageIdentifier: String?
@@ -59,18 +59,18 @@ public final class CalendarStoreViewController: UITabBarController {
     }
     
     /**
-     - parameter apiClient: An instance of `SchedJoulesApi`, initialized with a valid access token.
+     - parameter apiClient: An instance of `Api`, initialized with a valid access token.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
      - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
      - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
-    public init(apiClient: SchedJoulesApi, pageIdentifier: String?, title: String?, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
+    public init(apiClient: Api, pageIdentifier: String?, title: String?) {
         // Initialization
         self.apiClient = apiClient
         self.pageIdentifier = pageIdentifier
-        self.largeTitle = largeTitle
-        self.tintColor = tintColor
+        self.largeTitle = true
+        self.tintColor = ColorPalette.red
         homePageTitle = title
         super.init(nibName: nil, bundle: nil)
         
@@ -88,8 +88,8 @@ public final class CalendarStoreViewController: UITabBarController {
      - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
      - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
-    public convenience init(apiKey: String, pageIdentifier: String?, title: String?, largeTitle: Bool = true, tintColor: UIColor = ColorPalette.red) {
-        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title, largeTitle: largeTitle, tintColor: tintColor)
+    public convenience init(apiKey: String, pageIdentifier: String?, title: String?) {
+        self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title)
     }
     
     /**

--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -62,8 +62,6 @@ public final class CalendarStoreViewController: UITabBarController {
      - parameter apiClient: An instance of `Api`, initialized with a valid access token.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
-     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
-     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
     public init(apiClient: Api, pageIdentifier: String?, title: String?) {
         // Initialization
@@ -85,8 +83,6 @@ public final class CalendarStoreViewController: UITabBarController {
      - parameter apiKey: The API Key (access token) for the **SchedJoules API**.
      - parameter pageIdentifier: The page identifier for the the home page.
      - parameter title: The title for the `navigtaion bar` in the home page.
-     - parameter largeTitle: Set to `false` if you don't want to use large navigation bar titles.
-     - parameter tintColor: The tint color used through out the SDK, default is SchedJoules red.
      */
     public convenience init(apiKey: String, pageIdentifier: String?, title: String?) {
         self.init(apiClient: SchedJoulesApi(accessToken: apiKey), pageIdentifier: pageIdentifier, title: title)

--- a/SDK/ViewControllers/CalendarItemViewController.swift
+++ b/SDK/ViewControllers/CalendarItemViewController.swift
@@ -35,7 +35,7 @@ final class CalendarItemViewController: UIViewController {
     @IBOutlet weak var subscribeButton: UIButton!
     
     /// The Api client.
-    var apiClient: SchedJoulesApi!
+    var apiClient: Api!
     
     /// URL to the .ics file.
     var icsURL: URL!

--- a/SDK/ViewControllers/PageViewController.swift
+++ b/SDK/ViewControllers/PageViewController.swift
@@ -313,7 +313,7 @@ final class PageViewController<PageQuery: Query>: UIViewController, UITableViewD
             navigationController?.pushViewController(pageVC, animated: true)
         // Show the selected calendar
         } else {
-            let storyboard = UIStoryboard(name: "SDK", bundle: nil)
+            let storyboard = UIStoryboard(name: "SDK", bundle: Bundle.resourceBundle)
             let calendarVC = storyboard.instantiateViewController(withIdentifier: "CalendarItemViewController") as! CalendarItemViewController
             calendarVC.icsURL = URL(string: pageSection.items[indexPath.row].url)
             calendarVC.title = pageSection.items[indexPath.row].name

--- a/SDK/ViewControllers/PageViewController.swift
+++ b/SDK/ViewControllers/PageViewController.swift
@@ -46,7 +46,7 @@ final class PageViewController<PageQuery: Query>: UIViewController, UITableViewD
     private var tempPage: Page?
     
     /// The Api client.
-    private let apiClient: SchedJoulesApi
+    private let apiClient: Api
     
     /// The table view for presenting the pages.
     private var tableView: UITableView!
@@ -80,7 +80,7 @@ final class PageViewController<PageQuery: Query>: UIViewController, UITableViewD
      - parameter pageQuery: A query with a `Result` of type `Page`.
      - parameter searchEnabled: Set this parameter to true, if you would like to have a search controller present. Default is `false`.
      */
-    required init(apiClient: SchedJoulesApi, pageQuery: PageQuery, searchEnabled: Bool = false) {
+    required init(apiClient: Api, pageQuery: PageQuery, searchEnabled: Bool = false) {
         self.pageQuery = pageQuery
         self.apiClient = apiClient
         self.isSearchEnabled = searchEnabled

--- a/SDK/ViewControllers/Settings/SettingsDetailViewController.swift
+++ b/SDK/ViewControllers/Settings/SettingsDetailViewController.swift
@@ -50,7 +50,7 @@ final class SettingsDetailViewController<SettingsQuery: Query>: UIViewController
     private let settingsType: SettingsDetailType!
 
     /// The API Client.
-    private let apiClient: SchedJoulesApi
+    private let apiClient: Api
     
     /// Reference to the CalendarStoreViewController (used for reloading).
     private var calendarStoreViewController: CalendarStoreViewController?
@@ -74,7 +74,7 @@ final class SettingsDetailViewController<SettingsQuery: Query>: UIViewController
      Initialize with a query used to load the items which are going to be displayed.
      - parameter settingsQuery: A query with a `Result` of an array of a type that conforms to `CodedOption` protocol.
      */
-    required init(apiClient: SchedJoulesApi, settingsQuery: SettingsQuery, settingsType: SettingsDetailType) {
+    required init(apiClient: Api, settingsQuery: SettingsQuery, settingsType: SettingsDetailType) {
         self.apiClient = apiClient
         self.settingsQuery = settingsQuery
         self.settingsType = settingsType

--- a/SDK/ViewControllers/Settings/SettingsDetailViewController.swift
+++ b/SDK/ViewControllers/Settings/SettingsDetailViewController.swift
@@ -177,15 +177,6 @@ final class SettingsDetailViewController<SettingsQuery: Query>: UIViewController
         loadErrorView.center = view.center
         view.addSubview(loadErrorView)
     }
-
-    /// Read localization settings, use device defaults otherwise
-    func readSettings() -> [String] {
-        let languageSetting = UserDefaults.standard.value(forKey: "language_settings") as? Dictionary<String, String>
-        let locale = languageSetting != nil ? languageSetting!["countryCode"] : Locale.preferredLanguages[0].components(separatedBy: "-")[0]
-        let countrySetting = UserDefaults.standard.value(forKey: "country_settings") as? Dictionary<String, String>
-        let location = countrySetting != nil ? countrySetting!["countryCode"] : Locale.current.regionCode
-        return [locale!,location!]
-    }
     
     // MARK: - Table View Delegate and Data Source Methods
     
@@ -228,7 +219,7 @@ final class SettingsDetailViewController<SettingsQuery: Query>: UIViewController
             // Something other than default was selected
         } else {
             // Save selection to the user defaults
-            UserDefaults.standard.set(["displayName":items[indexPath.row].name,"countryCode":items[indexPath.row].code],
+            UserDefaults.standard.set(["displayName": items[indexPath.row].name, "countryCode": items[indexPath.row].code],
                                       forKey: "\(settingsType.rawValue)_settings")
         }
         

--- a/SDK/ViewControllers/Settings/SettingsViewController.swift
+++ b/SDK/ViewControllers/Settings/SettingsViewController.swift
@@ -34,7 +34,7 @@ final class SettingsViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
 
     /// The ApiClient.
-    var apiClient: SchedJoulesApi!
+    var apiClient: Api!
     
     // - MARK: Private Properties
     

--- a/SchedJoulesSDK.podspec
+++ b/SchedJoulesSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesSDK'
-  s.version          = '0.5.1'
+  s.version          = '0.6'
   s.summary          = 'The SchedJoules iOS SDK, written in Swift.'
  
   s.description      = <<-DESC

--- a/SchedJoulesSDK.podspec
+++ b/SchedJoulesSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesSDK'
-  s.version          = '0.5'
+  s.version          = '0.5.1'
   s.summary          = 'The SchedJoules iOS SDK, written in Swift.'
  
   s.description      = <<-DESC

--- a/iOS-SDK.xcodeproj/project.pbxproj
+++ b/iOS-SDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B625A60C20C038D000586F5E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B625A60520C038D000586F5E /* Main.storyboard */; };
 		B625A60D20C038D000586F5E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B625A60720C038D000586F5E /* AppDelegate.swift */; };
 		B625A60E20C038D000586F5E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B625A60820C038D000586F5E /* Info.plist */; };
+		B67696AA20C16BE200D57347 /* CalendarStoreSinglePageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67696A920C16BE200D57347 /* CalendarStoreSinglePageViewController.swift */; };
 		B69268872089F32A003456FB /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69268862089F32A003456FB /* PageViewController.swift */; };
 		B6D3E050204D97570044C800 /* iOS_SDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D3E04F204D97570044C800 /* iOS_SDKTests.swift */; };
 		B6EF1C4420780879003E0095 /* SDK.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6EF1C1120780878003E0095 /* SDK.storyboard */; };
@@ -50,6 +51,7 @@
 		B625A60620C038D000586F5E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		B625A60720C038D000586F5E /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B625A60820C038D000586F5E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B67696A920C16BE200D57347 /* CalendarStoreSinglePageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarStoreSinglePageViewController.swift; sourceTree = "<group>"; };
 		B69268862089F32A003456FB /* PageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
 		B6D3E037204D97570044C800 /* iOS-SDK.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-SDK.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6D3E04B204D97570044C800 /* iOS-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -158,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				B6EF1C3D20780879003E0095 /* CalendarStoreViewController.swift */,
+				B67696A920C16BE200D57347 /* CalendarStoreSinglePageViewController.swift */,
 				B6EF1C3820780879003E0095 /* ViewControllers */,
 				B6EF1C4120780879003E0095 /* Views */,
 				B60CC7E520B0AA7200CAE3BD /* Supporting Files */,
@@ -366,6 +369,7 @@
 				B625A5F020C037F400586F5E /* Bundle+ResourceBundle.swift in Sources */,
 				B6EF1C6520780879003E0095 /* LoadErrorView.swift in Sources */,
 				B6EF1C6320780879003E0095 /* CalendarItemViewController.swift in Sources */,
+				B67696AA20C16BE200D57347 /* CalendarStoreSinglePageViewController.swift in Sources */,
 				B69268872089F32A003456FB /* PageViewController.swift in Sources */,
 				B6EF1C5E20780879003E0095 /* SettingsDetailViewController.swift in Sources */,
 				B6EF1C6020780879003E0095 /* SettingsViewController.swift in Sources */,


### PR DESCRIPTION
- The Calendar Store can now be initialized as a single navigation controller, showing only the home page (i.e. no auxiliary pages and settings tab).
- Fixed a bug where the SDK storyboard was not loaded from the resource bundle.
- Removed unnecessary `readSettings()` function.