### PR TITLE
#64 Fix for crash on restore purchases

### DIFF
--- a/SDK/ViewControllers/Settings/SettingsViewController.swift
+++ b/SDK/ViewControllers/Settings/SettingsViewController.swift
@@ -135,6 +135,8 @@ final class SettingsViewController: UIViewController {
         // Set navbar title
         navigationItem.title = "Settings"
         view.addSubview(activityIndicator)
+        
+        storeManager.apiClient = self.apiClient
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Open the settings view, tap on restore purchases, the app won't crash