### PR TITLE
Fix crash and log product Id

### DIFF
--- a/SDK/Store/StoreManager.swift
+++ b/SDK/Store/StoreManager.swift
@@ -86,6 +86,7 @@ class StoreManager: NSObject {
         apiClient.execute(query: iapQuery, completion: { result in
             switch result {
             case let .success(resultInfo):
+                sjPrint("product for id: \(resultInfo.productId)")
                 completion(resultInfo, nil)
                 break
             case let .failure(error):

--- a/SDK/Store/StoreViewController.swift
+++ b/SDK/Store/StoreViewController.swift
@@ -51,7 +51,8 @@ class StoreViewController: UIViewController {
     }()
     
     var imageView: UIImageView = {
-        let imageView = UIImageView(image: #imageLiteral(resourceName: "purchase-intro-1"))
+        let image = UIImage(named: "purchase-intro-1")
+        let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
         return imageView


### PR DESCRIPTION
The apps that use the SDK crash since it can't find image "purchase-intro-1", seems that the problem is that in the SDK the image was assigned using imageLiteral, which apparently casues problems with cocoapods.

This commit also adds a log for the product identifier