### PR TITLE
Fix image bundle for store image & podspec update

### DIFF
--- a/SDK/Store/StoreViewController.swift
+++ b/SDK/Store/StoreViewController.swift
@@ -51,7 +51,7 @@ class StoreViewController: UIViewController {
     }()
     
     var imageView: UIImageView = {
-        let image = UIImage(named: "purchase-intro-1")
+        let image = UIImage(named: "purchase-intro-1", in: Bundle.resourceBundle, compatibleWith: nil)
         let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit

--- a/SchedJoulesSDK.podspec
+++ b/SchedJoulesSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesSDK'
-  s.version          = '0.9.1'
+  s.version          = '0.9.2'
   s.summary          = 'The SchedJoules iOS SDK, written in Swift.'
  
   s.description      = <<-DESC


### PR DESCRIPTION
This PR fixes the issue about the pod not recognizing an image because the bundle wasn't set.