### PR TITLE
#91 Remove "Next" tab

### DIFF
--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -154,12 +154,6 @@ public final class CalendarStoreViewController: UITabBarController {
         newVC.tabBarItem.image = UIImage(named: "New", in: Bundle.resourceBundle, compatibleWith: nil)
         tabViewControllers.append(newVC)
         
-        // Create next page
-        let nextVC = PageViewController(apiClient: apiClient, pageQuery: NextPageQuery(numberOfItems: 12, locale: languageSetting.code))
-        nextVC.title = "Next"
-        nextVC.tabBarItem.image = UIImage(named: "Next", in: Bundle.resourceBundle, compatibleWith: nil)
-        tabViewControllers.append(nextVC)
-        
         // Create settings page
         let storyBoard = UIStoryboard(name: "SDK", bundle: Bundle.resourceBundle)
         let settingsVC = storyBoard.instantiateViewController(withIdentifier: "SettingsViewController") as! SettingsViewController


### PR DESCRIPTION
Based on this comment from a client: "I don't understand what the "Next" tab in the CalendarStore is about? Can you explain what this is?", it was decided to remove the tab from the app. The related elements remain in case we want to add it back in the future.