### PR TITLE
#93 Add an option in the .plist for users to change the support email for calendars

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -46,5 +46,7 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>To show you the weather map</string>
+	<key>CalendarStoreFeedbackEmailAddress</key>
+	<string>support@schedjoules.com</string>
 </dict>
 </plist>

--- a/SDK/ViewControllers/Settings/SettingsViewController.swift
+++ b/SDK/ViewControllers/Settings/SettingsViewController.swift
@@ -94,13 +94,13 @@ final class SettingsViewController: UIViewController {
     
     private let purchasesItems = [Item(title: "Restore Purchases")]
     
-    /// Contact menu items.
+    private static let supportEmail: String = Bundle.main.object(forInfoDictionaryKey: "CalendarStoreFeedbackEmailAddress") as? String ?? "support@schedjoules.com"
     private let contactItems = [Item(title: "FAQ",
                                      details: nil,
                                      data: URL(string: "https://cms.schedjoules.com/static_pages/help_\(Locale.preferredLanguages[0].components(separatedBy: "-")[0]).html")),
                                 Item(title: "e-mail",
-                                     details: "support@schedjoules.com",
-                                     data: "support@schedjoules.com"),
+                                     details: supportEmail,
+                                     data: supportEmail),
                                 Item(title: "Twitter",
                                      details: "@schedjoules",
                                      data: URL(string:"https://twitter.com/SchedJoules")),


### PR DESCRIPTION
This PR adds a feature available in the old SDK where users had the option to add an email to receive support requests from the public calendars SDK. This feature wasn't scoped but was recently brought up by a client.

To test go to the .plist and look for the key "CalendarStoreFeedbackEmailAddress" after changing it run the app and go to settings, there the new support email will be visible.