### PR TITLE
#96 Filter out the products that don't belong to SchedJoules while restoring purchases

### DIFF
--- a/SDK/Store/StoreManager.swift
+++ b/SDK/Store/StoreManager.swift
@@ -230,7 +230,8 @@ extension StoreManager: SKPaymentTransactionObserver {
     
     public func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         if isRestoringPurchases == true {
-            let restoreTransactions = transactions.filter({ $0.transactionState == .restored })
+            let allRestoreTransactions = transactions.filter({ $0.transactionState == .restored })
+            let restoreTransactions = allRestoreTransactions.filter({ $0.payment.productIdentifier.hasPrefix("com.schedjoules") })
             let sortedTransactions = restoreTransactions.sorted(by: {
                 let firstTimeInterval = $0.transactionDate?.timeIntervalSince1970 ?? 0
                 let secondTimeInterval = $1.transactionDate?.timeIntervalSince1970 ?? 0


### PR DESCRIPTION
One of our clients brought to our attention that restoring purchases was failing for some of his apps, the reason is that we only restore the latest purchase, but some purchases belonged to his products which was causing that our product purchase wasn't restored properly.