### PR TITLE
#94 #95 Inform the hosting app of changes in the calendars

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -25,11 +25,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let calendarVC = CalendarStoreViewController(apiKey: "0443a55244bb2b6224fd48e0416f0d9c", title: "Featured")
         calendarVC.calendarStoreDelegate = self
         
+        //Add observer to listen for subscribe notifications
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(subscribedToCalendar(_:)),
+                                               name: .subscribedToCalendar,
+                                               object: nil)
+        
         // Show the calendar store
         window?.rootViewController = calendarVC
         window?.makeKeyAndVisible()
         
         return true
+    }
+    
+    @objc private func subscribedToCalendar(_ notification: Notification) {
+        sjPrint(notification)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -23,6 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Initialize the calendar store
         let calendarVC = CalendarStoreViewController(apiKey: "0443a55244bb2b6224fd48e0416f0d9c", title: "Featured")
+        calendarVC.calendarStoreDelegate = self
         
         // Show the calendar store
         window?.rootViewController = calendarVC
@@ -55,4 +56,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 
+}
+
+
+extension AppDelegate: CalendarStoreDelegate {
+    
+    func calendarStoreDidClose() {
+        sjPrint("Delegate did close")
+    }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Alamofire (4.9.0)
   - Result (4.0.1)
-  - SchedJoulesApiClient (0.7.7):
+  - SchedJoulesApiClient (0.7.8):
     - Alamofire (~> 4.5)
     - Result (~> 4.0.0)
   - SDWebImage (4.4.7):
@@ -22,7 +22,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: afc3e7c6db61476cb45cdd23fed06bad03bbc321
   Result: a6e784bebf48b471d59cddc1adb81f41f678c487
-  SchedJoulesApiClient: 7c98cb606d925fe80be3af6d9cbefd13ce6f3d59
+  SchedJoulesApiClient: 0c37cbb48f9220e085d119b9f580a04cc3b9a7a3
   SDWebImage: c10d14a8883ebd89664f02a422006f66a85c0c5d
 
 PODFILE CHECKSUM: 019309180a8611256af3fcbc7c19231a65102d26

--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -26,7 +26,14 @@
 import UIKit
 import SchedJoulesApiClient
 
+@objc protocol CalendarStoreDelegate: class {
+    func calendarStoreDidClose()
+}
+
 public final class CalendarStoreViewController: UITabBarController {
+    /// Delegate
+    weak var calendarStoreDelegate: CalendarStoreDelegate?
+    
     /// Colors used by the SDK.
     public struct ColorPalette {
         public static let red = UIColor(red: 241/255.0, green: 102/255.0, blue: 103/255.0, alpha: 1)
@@ -187,6 +194,8 @@ public final class CalendarStoreViewController: UITabBarController {
     }
     
     @objc private func close() {
+        calendarStoreDelegate?.calendarStoreDidClose()
+        
         if navigationController != nil {
             navigationController?.popViewController(animated: true)
         } else {

--- a/SDK/Utils/Config.swift
+++ b/SDK/Utils/Config.swift
@@ -46,5 +46,5 @@ class Config {
         return Int(Date().timeIntervalSince1970)
     }
     
-    static let libraryVersion: String = "2.3.4-4-g8cd554c"
+    static let libraryVersion: String = "0.7.8"
 }

--- a/SDK/Utils/Extensions/NotificationName.swift
+++ b/SDK/Utils/Extensions/NotificationName.swift
@@ -1,0 +1,15 @@
+//
+//  NotificationName.swift
+//  iOS-SDK
+//
+//  Created by Alberto Huerdo on 10/1/19.
+//  Copyright © 2019 SchedJoules. All rights reserved.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static var subscribedToCalendar: Notification.Name {
+        return .init("CalendarStore.subscribed")
+    }
+}

--- a/SDK/ViewControllers/CalendarItemViewController.swift
+++ b/SDK/ViewControllers/CalendarItemViewController.swift
@@ -123,6 +123,7 @@ final class CalendarItemViewController: UIViewController {
         }
         
         UIApplication.shared.open(webcal, options: [:], completionHandler: nil)
+        NotificationCenter.default.post(name: .subscribedToCalendar, object: webcal)
     }
     
     // Show network indicator and activity indicator

--- a/SDK/ViewControllers/PageViewController.swift
+++ b/SDK/ViewControllers/PageViewController.swift
@@ -194,6 +194,7 @@ final class PageViewController<PageQuery: Query>: UIViewController, UITableViewD
         }
         
         UIApplication.shared.open(webcal, options: [:], completionHandler: nil)
+        NotificationCenter.default.post(name: .subscribedToCalendar, object: webcal)
     }
     
     /// Set up the activity indicator in the view and start loading

--- a/SDK/ViewControllers/WeatherMap/WeatherDetailViewController.swift
+++ b/SDK/ViewControllers/WeatherMap/WeatherDetailViewController.swift
@@ -232,6 +232,7 @@ class WeatherDetailViewController: UIViewController {
         
         //Open calendar to subscribe
         UIApplication.shared.open(webcal, options: [:], completionHandler: nil)
+        NotificationCenter.default.post(name: .subscribedToCalendar, object: webcal)
     }
     
 }

--- a/iOS-SDK.xcodeproj/project.pbxproj
+++ b/iOS-SDK.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		460015582208987300C6E9F2 /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460015502208987300C6E9F2 /* AnalyticsTracker.swift */; };
 		4610CD16228DD54800CE25C2 /* Reach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4610CD15228DD53F00CE25C2 /* Reach.swift */; };
 		46214AA3222913DE00A92F39 /* UIApplicationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46214AA2222913DE00A92F39 /* UIApplicationExtension.swift */; };
+		4629919423435B8000CA8292 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4629919323435B8000CA8292 /* NotificationName.swift */; };
 		465569F321C537FA00FE7064 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465569F221C537FA00FE7064 /* SettingsManager.swift */; };
 		4657B81322BA106C003A2AE4 /* UITapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4657B81222BA106C003A2AE4 /* UITapGestureRecognizer.swift */; };
 		4657B82322BCE174003A2AE4 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4657B82222BCE174003A2AE4 /* DateExtension.swift */; };
@@ -74,6 +75,7 @@
 		460015502208987300C6E9F2 /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		4610CD15228DD53F00CE25C2 /* Reach.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reach.swift; sourceTree = "<group>"; };
 		46214AA2222913DE00A92F39 /* UIApplicationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationExtension.swift; sourceTree = "<group>"; };
+		4629919323435B8000CA8292 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		464F7BCA2233D1AE00907906 /* iOS-SDK.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "iOS-SDK.entitlements"; sourceTree = "<group>"; };
 		465569F221C537FA00FE7064 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		4657B81222BA106C003A2AE4 /* UITapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITapGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				460015492208987300C6E9F2 /* ArrayExtension.swift */,
 				46F45C5022607E800005EAB6 /* Bundle+ResourceBundle.swift */,
 				4657B82222BCE174003A2AE4 /* DateExtension.swift */,
+				4629919323435B8000CA8292 /* NotificationName.swift */,
 				469AA7AC23215D7D0092CBA1 /* StringExtension.swift */,
 				46214AA2222913DE00A92F39 /* UIApplicationExtension.swift */,
 				46F45C5622608BA00005EAB6 /* UIColorExtension.swift */,
@@ -458,7 +461,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\n";
+			shellScript = "
+";
 		};
 		54B00ED1695F2B9D6231B8D5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -494,6 +498,7 @@
 				460015522208987300C6E9F2 /* SJLogger.swift in Sources */,
 				46F45C5522608B5D0005EAB6 /* StoreManager.swift in Sources */,
 				460015552208987300C6E9F2 /* ArrayExtension.swift in Sources */,
+				4629919423435B8000CA8292 /* NotificationName.swift in Sources */,
 				46F45C5422608B5D0005EAB6 /* StoreViewController.swift in Sources */,
 				B625A60D20C038D000586F5E /* AppDelegate.swift in Sources */,
 				469AA7A223215C830092CBA1 /* WeatherSettingsView.swift in Sources */,

--- a/iOS-SDK.xcodeproj/xcshareddata/xcschemes/iOS-SDK.xcscheme
+++ b/iOS-SDK.xcodeproj/xcshareddata/xcschemes/iOS-SDK.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B6D3E036204D97570044C800"
+            BuildableName = "iOS-SDK.app"
+            BlueprintName = "iOS-SDK"
+            ReferencedContainer = "container:iOS-SDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B6D3E036204D97570044C800"
-            BuildableName = "iOS-SDK.app"
-            BlueprintName = "iOS-SDK"
-            ReferencedContainer = "container:iOS-SDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"


### PR DESCRIPTION
This Pr includes issues #94 and #95 since their goal is to inform the hosting app about actions in the calendar sdk.

#94 now users can set their launching class to conform to the `CalendarStoreDelegate` and be notified when the CalendarStore is closed.

#95 users can also listen for a notification named `subscribedToCalendar` that will inform them when a user opens a calendar url, informing which the url of the calendar.