### PR TITLE
#99 Fix for Crash when presenting the error alert of StoreManager

### DIFF
--- a/SDK/Store/StoreViewController.swift
+++ b/SDK/Store/StoreViewController.swift
@@ -366,24 +366,26 @@ extension StoreViewController: InteractableStoreManager {
     }
     
     func purchaseFailed(errorDescription: String?) {
-        mainActivityIndicator.stopAnimating()
-        productActivityIndicator.stopAnimating()
-        
-        let message = errorDescription ?? "Your request failed"
-        
-        let alertController = UIAlertController(title: "Error",
-                                                message: message,
-                                                preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "Dismiss",
-                                     style: .default) { (action) in
-                                        self.dismiss()
-                                        alertController.dismiss(animated: true, completion: {
-                                            self.tapCloseButton()
-                                        })
+        DispatchQueue.main.async {
+            self.mainActivityIndicator.stopAnimating()
+            self.productActivityIndicator.stopAnimating()
+            
+            let message = errorDescription ?? "Your request failed"
+            
+            let alertController = UIAlertController(title: "Error",
+                                                    message: message,
+                                                    preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "Dismiss",
+                                         style: .default) { (action) in
+                                            self.dismiss()
+                                            alertController.dismiss(animated: true, completion: {
+                                                self.tapCloseButton()
+                                            })
+            }
+            alertController.addAction(okAction)
+            
+            self.present(alertController, animated: true, completion: nil)
         }
-        alertController.addAction(okAction)
-        
-        present(alertController, animated: true, completion: nil)
     }
     
 }


### PR DESCRIPTION
When the error alert in StoreManager was presented, the layout modifications were called from the main thread, in Xcode 11 instead of a warning the app crashes. This PR fixes that bug.