### PR TITLE
Update SchedJoulesSDK to 0.9.5

### DIFF
--- a/SchedJoulesSDK.podspec
+++ b/SchedJoulesSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesSDK'
-  s.version          = '0.9.4'
+  s.version          = '0.9.5'
   s.summary          = 'The SchedJoules iOS SDK, written in Swift.'
  
   s.description      = <<-DESC


### PR DESCRIPTION
This PR updates the podspec to a new version that will include:
- Remove the Next bar- 
- Fixes for crashes caused by modifying the layout outside of the main thread
- Add feature to change the support email
- Add button to dismiss the Calendar Store
- Fix missing user id parameter when subscribing to a calendar
- Add Delegate method to inform the hosting app when the Calendar Store closes
- Add Notification to inform the hosting app when a `webcam` link is open
