### PR TITLE
#50 Open calendar with first upcoming event

### DIFF
--- a/SDK/ViewControllers/CalendarItemViewController.swift
+++ b/SDK/ViewControllers/CalendarItemViewController.swift
@@ -111,20 +111,13 @@ final class CalendarItemViewController: UIViewController {
     }
     
     //Scroll to the next upcoming Event
-    private func scrollToNextEvent(in calendar: ICalendar?) {
-        guard let nextUpcomingEvent = calendar?.events.filter({ (event) -> Bool in
-            //The SDK considers endDates as optionals, therefore if we can't compare an endDate we use startDate
-            let dateForFilter: Date = event.endDate ?? event.startDate
+    private func scrollToNextEvent(in calendar: ICalendar?) {        
+        let indexOfUpcomingEvent = calendar?.events.firstIndex(where: { (event) -> Bool in
+            let dateForFilter: Date = event.endDate ?? event.startDate            
             return Calendar.current.compare(dateForFilter,
                                             to: Date(),
-                                            toGranularity: .hour) == .orderedDescending
-        }).first else {
-            return
-        }
-        
-        let indexOfUpcomingEvent = calendar?.events.firstIndex { (event) -> Bool in
-            event.startDate == nextUpcomingEvent.startDate
-        }
+                                            toGranularity: .second) == .orderedDescending
+        })
         
         self.tableView.scrollToRow(at: IndexPath(row: indexOfUpcomingEvent ?? 0, section: 0), at: .top, animated: true)
     }

--- a/SDK/ViewControllers/CalendarItemViewController.swift
+++ b/SDK/ViewControllers/CalendarItemViewController.swift
@@ -90,8 +90,10 @@ final class CalendarItemViewController: UIViewController {
     func loadICS(){
         apiClient.execute(query: CalendarQuery(url: icsURL), completion: { result in
             switch result {
-            case let .success(calendar):
-                self.calendar = calendar
+            case let .success(calendar):                
+                let upcomingEvents = calendar.events.filter({ $0.startDate > Date() })
+                let upcomingCalendar = ICalendar(events: upcomingEvents)
+                self.calendar = upcomingCalendar
                 
                 AnalyticsTracker.shared().trackScreen(name: self.title, page: nil, url: self.icsURL)
                 

--- a/SDK/ViewControllers/CalendarItemViewController.swift
+++ b/SDK/ViewControllers/CalendarItemViewController.swift
@@ -112,13 +112,21 @@ final class CalendarItemViewController: UIViewController {
     
     //Scroll to the next upcoming Event
     private func scrollToNextEvent(in calendar: ICalendar?) {
-        guard let nextUpcomingEvent = calendar?.events.filter({ $0.startDate > Date() }).first else { return }
-            
+        guard let nextUpcomingEvent = calendar?.events.filter({ (event) -> Bool in
+            //The SDK considers endDates as optionals, therefore if we can't compare an endDate we use startDate
+            let dateForFilter: Date = event.endDate ?? event.startDate
+            return Calendar.current.compare(dateForFilter,
+                                            to: Date(),
+                                            toGranularity: .hour) == .orderedDescending
+        }).first else {
+            return
+        }
+        
         let indexOfUpcomingEvent = calendar?.events.firstIndex { (event) -> Bool in
-                event.startDate == nextUpcomingEvent.startDate
-            }
-            
-            self.tableView.scrollToRow(at: IndexPath(row: indexOfUpcomingEvent ?? 0, section: 0), at: .top, animated: true)
+            event.startDate == nextUpcomingEvent.startDate
+        }
+        
+        self.tableView.scrollToRow(at: IndexPath(row: indexOfUpcomingEvent ?? 0, section: 0), at: .top, animated: true)
     }
     
     // Subscribe button pressed


### PR DESCRIPTION
When opening a calendar, show the first upcoming event on top instead of the oldest available event in the calendar, in this PR we filter out the events that happen before today.