### PR TITLE
Fix for transparent navigation bar in iOS 13.

### DIFF
--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -190,7 +190,13 @@ public final class CalendarStoreViewController: UITabBarController {
             if #available(iOS 11.0, *) {
                 navigationController.navigationBar.prefersLargeTitles = largeTitle
             }
-            
+            if #available(iOS 13.0, *) {
+                navigationController.navigationBar.backgroundColor
+                    = .systemBackground
+            } else {
+                // Fallback on earlier versions
+            }
+
             if showCloseButton == true &&
                 $0.title == homePageTitle {
                 let doneButton = UIBarButtonItem(barButtonSystemItem: .done,

--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -191,10 +191,7 @@ public final class CalendarStoreViewController: UITabBarController {
                 navigationController.navigationBar.prefersLargeTitles = largeTitle
             }
             if #available(iOS 13.0, *) {
-                navigationController.navigationBar.backgroundColor
-                    = .systemBackground
-            } else {
-                // Fallback on earlier versions
+                navigationController.navigationBar.backgroundColor = .systemBackground
             }
 
             if showCloseButton == true &&


### PR DESCRIPTION
The navigation bar is transparent on iOS 13 and thise leaves the view behind it visible. The background color is now set to system background color which is dark mode compatible.