### PR TITLE
#125 Remove intro screens for clients

### DIFF
--- a/SDK/CalendarStoreViewController.swift
+++ b/SDK/CalendarStoreViewController.swift
@@ -126,16 +126,6 @@ public final class CalendarStoreViewController: UITabBarController {
         Reach().monitorReachabilityChanges()
     }
     
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if UserDefaults.standard.hasSeenIntro == false {
-            let introPages = SJIntroViewController()
-            present(introPages, animated: true)
-        }
-
-    }
-    
     // - MARK: Helper Methods
     
     // Add the view controllers to the tab bar controller


### PR DESCRIPTION
We shouldn't show the intro screens to the clients, so in this PR I removed the code that launches it.

This is a quick fix, still need to figure out a way to present it just for us.

Maybe take them out completely from the SDK and move it to our base project or use the bundle id to avoid launching