### PR TITLE
Update SchedJoulesSDK to 0.9.8

### DIFF
--- a/SchedJoulesSDK.podspec
+++ b/SchedJoulesSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesSDK'
-  s.version          = '0.9.7'
+  s.version          = '0.9.8'
   s.summary          = 'The SchedJoules iOS SDK, written in Swift.'
  
   s.description      = <<-DESC


### PR DESCRIPTION
Merge after PR: Remove intro screens https://github.com/schedjoules/ios-public-calendars-sdk/pull/126

##This version will include the follow changes:
1. Disable intro screens
2. Add an accessibility identifier for the done button, on the intro screens, suggested by Gahm
3. Workaround for empty NavBar, suggested by Gahm